### PR TITLE
Fix binding negative ints

### DIFF
--- a/lib/bind.ml
+++ b/lib/bind.ml
@@ -116,11 +116,11 @@ let short ?(unsigned = false) b param ~at =
     ~at
 
 let int ?(unsigned = false) b param ~at =
-  let p = allocate int param in
+  let p = allocate llong (Signed.LLong.of_int param) in
   bind b
-    ~buffer:(coerce (ptr int) (ptr void) p)
-    ~size:(sizeof int)
-    ~mysql_type:T.Type.long
+    ~buffer:(coerce (ptr llong) (ptr void) p)
+    ~size:(sizeof llong)
+    ~mysql_type:T.Type.long_long
     ~unsigned:(if unsigned then yes else no)
     ~at
 


### PR DESCRIPTION
Fixes #31.
There is also a PR #48 which narrows down the integer to 32 bits instead, which is worse IMO because it will break working with BIGINT fields.