### PR TITLE
Avoid possibly blocking calls to mysql_free_result.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install system dependencies (ubuntu)
         if: "${{ matrix.os == 'ubuntu' }}"
-        run: "apt-get update && apt-get install -y pkg-config libmariadb-dev"
+        run: "apt-get update && apt-get install -y pkg-config libmariadb-dev libzstd-dev"
 
       - name: Restore cached dependencies
         uses: actions/cache@v3

--- a/bindings/ffi_bindings.ml
+++ b/bindings/ffi_bindings.ml
@@ -346,6 +346,12 @@ module Functions (F : Ctypes.FOREIGN) = struct
 
   (* Nonblocking API *)
 
+  let mysql_free_result_start = foreign "mysql_free_result_start"
+    (res @-> returning int)
+
+  let mysql_free_result_cont = foreign "mysql_free_result_cont"
+    (res @-> int @-> returning int)
+
   let mysql_close_start = foreign "mysql_close_start"
     (mysql @-> returning int)
 

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -375,15 +375,8 @@ module Stmt = struct
         b.Bind.buffers.(i) <- malloc n;
         setf (!@bp) T.Bind.buffer b.Bind.buffers.(i)
 
-  let free_meta stmt =
-    match stmt.meta with
-    | Some { res; _ } ->
-        B.mysql_free_result res;
-        stmt.meta <- None
-    | None -> ()
-
   let update_meta stmt =
-    free_meta stmt;
+    assert (stmt.meta = None);
     stmt.meta <- (
         match B.mysql_stmt_result_metadata stmt.raw with
         | Some res ->


### PR DESCRIPTION
The blocking calls could only occur if the result set from a previous Stmt.execute has not been fetched.

Fixes #67.